### PR TITLE
Add support for getting variant names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## Unreleased
+
+-   Add `VariantNames` macro [#1](https://github.com/TedDriggs/field_names/issues/1)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://github.com/TedDriggs/field_names/workflows/CI/badge.svg)](https://github.com/TedDriggs/field_names/actions)
 [![Latest Version](https://img.shields.io/crates/v/field_names.svg)](https://crates.io/crates/field_names)
 
-`field_names` is a Rust proc-macro that exposes a struct's field names as strings at runtime.
+`field_names` is a Rust crate to expose a field or variant names from source code as strings at runtime.
 
 # Example
 
@@ -31,6 +31,30 @@ impl Example {
 }
 ```
 
+Enums are the same:
+
+```rust
+#[derive(VariantNames)]
+enum Example {
+    Hello(String),
+    #[variant_names(skip)]
+    Secret(String),
+    World,
+}
+```
+
+`field_names` will emit the following:
+
+```rust
+#[automatically_derived]
+impl Example {
+    const VARIANTS: [&'static str; 2] = [
+        "Hello",
+        "World",
+    ];
+}
+```
+
 # Uses
 
 This crate was originally created for a case where a set of rules were being read at runtime which referenced fields of structs elsewhere in the code base.
@@ -39,10 +63,15 @@ With this crate, a unit test could be created to ensure that every field on the 
 
 # FAQs
 
-### Why isn't `FieldNames` a trait?
+### Why aren't `FieldNames` and `VariantNames` traits?
 
 Using `field_names` is an implementation convenience; it shouldn't force you to change your crate's public API.
 
-### How do I make `FIELDS` public?
+### How do I make `FIELDS` or `VARIANTS` public?
 
 You can add your own inherent method, e.g. `fields() -> &[&'static str]`, or define a trait that matches your use-case and reference `FIELDS` in the trait implementation.
+
+### Can I get field names for an enum variant?
+
+This currently isn't supported, using newtype variants and separate structs per variant is currently the recommended approach.
+You can use the [`from_variants`](https://crates.io/crates/from_variants) crate to auto-generate conversions from those structs into the enum.

--- a/examples/variants.rs
+++ b/examples/variants.rs
@@ -1,0 +1,18 @@
+#![allow(dead_code)]
+
+use field_names::VariantNames;
+
+#[derive(VariantNames)]
+enum Example {
+    Hello(String),
+    #[variant_names(skip)]
+    Secret(String),
+    World {
+        planet: String,
+        person: String,
+    },
+}
+
+fn main() {
+    println!("{:?}", Example::VARIANTS);
+}

--- a/src/fields.rs
+++ b/src/fields.rs
@@ -1,0 +1,103 @@
+use darling::{ast::Data, FromDeriveInput, FromField};
+use proc_macro2::TokenStream;
+use quote::{quote, ToTokens};
+use syn::{Generics, Ident};
+
+#[derive(FromDeriveInput)]
+#[darling(supports(struct_named))]
+pub(crate) struct Receiver {
+    ident: Ident,
+    generics: Generics,
+    data: Data<(), ReceiverField>,
+}
+
+impl Receiver {
+    fn fields_to_emit(&self) -> Vec<String> {
+        self.data
+            .as_ref()
+            .take_struct()
+            .expect("FieldNames only supports named structs")
+            .into_iter()
+            .filter(|field| !field.skip)
+            .map(|field| field.name())
+            .collect()
+    }
+}
+
+impl ToTokens for Receiver {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let ident = &self.ident;
+        let (impl_generics, ty_generics, where_clause) = self.generics.split_for_impl();
+        let fields = self.fields_to_emit();
+        let fields_len = fields.len();
+
+        tokens.extend(quote! {
+            #[automatically_derived]
+            impl #impl_generics #ident #ty_generics #where_clause {
+                const FIELDS: [&'static str; #fields_len] = [
+                    #(#fields),*
+                ];
+            }
+        })
+    }
+}
+
+#[derive(FromField)]
+#[darling(attributes(field_names))]
+struct ReceiverField {
+    ident: Option<Ident>,
+    #[darling(default)]
+    skip: bool,
+}
+
+impl ReceiverField {
+    fn name(&self) -> String {
+        self.ident
+            .as_ref()
+            .expect("FieldNames only supports named fields")
+            .to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Receiver;
+    use darling::FromDeriveInput;
+    use syn::parse_quote;
+
+    #[test]
+    fn simple() {
+        let input = Receiver::from_derive_input(&parse_quote! {
+            #[derive(FieldNames)]
+            struct Example {
+                hello: String,
+                world: String,
+            }
+        })
+        .unwrap();
+
+        assert_eq!(
+            input.fields_to_emit(),
+            vec!["hello".to_string(), "world".to_string()]
+        );
+    }
+
+    #[test]
+    fn skip_field() {
+        let input = Receiver::from_derive_input(&parse_quote! {
+            #[derive(FieldNames)]
+            struct Example {
+                hello: String,
+                #[field_names(skip)]
+                hidden: bool,
+                world: String,
+            }
+        })
+        .unwrap();
+
+        assert_eq!(
+            input.fields_to_emit(),
+            vec!["hello".to_string(), "world".to_string()]
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,10 +5,19 @@ use quote::quote;
 use syn::{parse_macro_input, DeriveInput};
 
 mod fields;
+mod variants;
 
 #[proc_macro_derive(FieldNames, attributes(field_names))]
 pub fn derive_field_names(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     fields::Receiver::from_derive_input(&parse_macro_input!(input as DeriveInput))
+        .map(|receiver| quote!(#receiver))
+        .unwrap_or_else(|err| err.write_errors())
+        .into()
+}
+
+#[proc_macro_derive(VariantNames, attributes(variant_names))]
+pub fn derive_variant_names(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    variants::Receiver::from_derive_input(&parse_macro_input!(input as DeriveInput))
         .map(|receiver| quote!(#receiver))
         .unwrap_or_else(|err| err.write_errors())
         .into()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,113 +1,15 @@
 extern crate proc_macro;
 
-use darling::{ast::Data, FromDeriveInput, FromField};
-use proc_macro2::TokenStream;
-use quote::{quote, ToTokens};
-use syn::{parse_macro_input, DeriveInput, Generics, Ident};
+use darling::FromDeriveInput;
+use quote::quote;
+use syn::{parse_macro_input, DeriveInput};
+
+mod fields;
 
 #[proc_macro_derive(FieldNames, attributes(field_names))]
 pub fn derive_field_names(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    Receiver::from_derive_input(&parse_macro_input!(input as DeriveInput))
+    fields::Receiver::from_derive_input(&parse_macro_input!(input as DeriveInput))
         .map(|receiver| quote!(#receiver))
         .unwrap_or_else(|err| err.write_errors())
         .into()
-}
-
-#[derive(FromDeriveInput)]
-#[darling(supports(struct_named))]
-struct Receiver {
-    ident: Ident,
-    generics: Generics,
-    data: Data<(), ReceiverField>,
-}
-
-impl Receiver {
-    fn fields_to_emit(&self) -> Vec<String> {
-        self.data
-            .as_ref()
-            .take_struct()
-            .expect("FieldNames only supports named structs")
-            .into_iter()
-            .filter(|field| !field.skip)
-            .map(|field| field.name())
-            .collect()
-    }
-}
-
-impl ToTokens for Receiver {
-    fn to_tokens(&self, tokens: &mut TokenStream) {
-        let ident = &self.ident;
-        let (impl_generics, ty_generics, where_clause) = self.generics.split_for_impl();
-        let fields = self.fields_to_emit();
-        let fields_len = fields.len();
-
-        tokens.extend(quote! {
-            #[automatically_derived]
-            impl #impl_generics #ident #ty_generics #where_clause {
-                const FIELDS: [&'static str; #fields_len] = [
-                    #(#fields),*
-                ];
-            }
-        })
-    }
-}
-
-#[derive(FromField)]
-#[darling(attributes(field_names))]
-struct ReceiverField {
-    ident: Option<Ident>,
-    #[darling(default)]
-    skip: bool,
-}
-
-impl ReceiverField {
-    fn name(&self) -> String {
-        self.ident
-            .as_ref()
-            .expect("FieldNames only supports named fields")
-            .to_string()
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::Receiver;
-    use darling::FromDeriveInput;
-    use syn::parse_quote;
-
-    #[test]
-    fn simple() {
-        let input = Receiver::from_derive_input(&parse_quote! {
-            #[derive(FieldNames)]
-            struct Example {
-                hello: String,
-                world: String,
-            }
-        })
-        .unwrap();
-
-        assert_eq!(
-            input.fields_to_emit(),
-            vec!["hello".to_string(), "world".to_string()]
-        );
-    }
-
-    #[test]
-    fn skip_field() {
-        let input = Receiver::from_derive_input(&parse_quote! {
-            #[derive(FieldNames)]
-            struct Example {
-                hello: String,
-                #[field_names(skip)]
-                hidden: bool,
-                world: String,
-            }
-        })
-        .unwrap();
-
-        assert_eq!(
-            input.fields_to_emit(),
-            vec!["hello".to_string(), "world".to_string()]
-        );
-    }
 }

--- a/src/variants.rs
+++ b/src/variants.rs
@@ -1,0 +1,100 @@
+use darling::{ast::Data, FromDeriveInput, FromVariant};
+use proc_macro2::TokenStream;
+use quote::{quote, ToTokens};
+use syn::{Generics, Ident};
+
+#[derive(FromDeriveInput)]
+#[darling(supports(enum_any))]
+pub(crate) struct Receiver {
+    ident: Ident,
+    generics: Generics,
+    data: Data<ReceiverVariant, ()>,
+}
+
+impl Receiver {
+    fn variants_to_emit(&self) -> Vec<String> {
+        self.data
+            .as_ref()
+            .take_enum()
+            .expect("VariantNames only takes enums")
+            .into_iter()
+            .filter(|v| !v.skip)
+            .map(|v| v.ident.to_string())
+            .collect()
+    }
+}
+
+impl ToTokens for Receiver {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let ident = &self.ident;
+        let (impl_generics, ty_generics, where_clause) = self.generics.split_for_impl();
+        let variants = self.variants_to_emit();
+        let variants_len = variants.len();
+
+        tokens.extend(quote! {
+            #[automatically_derived]
+            impl #impl_generics #ident #ty_generics #where_clause {
+                const VARIANTS: [&'static str; #variants_len] = [
+                    #(#variants),*
+                ];
+            }
+        })
+    }
+}
+
+#[derive(FromVariant)]
+#[darling(attributes(variant_names))]
+struct ReceiverVariant {
+    ident: Ident,
+    #[darling(default)]
+    skip: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Receiver;
+    use darling::FromDeriveInput;
+    use syn::parse_quote;
+
+    #[test]
+    fn simple() {
+        let input = Receiver::from_derive_input(&parse_quote! {
+            #[derive(VariantNames)]
+            enum Example {
+                Hello(String),
+                World {
+                    planet: String,
+                    person: String,
+                }
+            }
+        })
+        .unwrap();
+
+        assert_eq!(
+            input.variants_to_emit(),
+            vec!["Hello".to_string(), "World".to_string()]
+        );
+    }
+
+    #[test]
+    fn skip_variant() {
+        let input = Receiver::from_derive_input(&parse_quote! {
+            #[derive(VariantNames)]
+            enum Example {
+                Hello(String),
+                #[variant_names(skip)]
+                Secret(String),
+                World {
+                    planet: String,
+                    person: String,
+                },
+            }
+        })
+        .unwrap();
+
+        assert_eq!(
+            input.variants_to_emit(),
+            vec!["Hello".to_string(), "World".to_string()]
+        );
+    }
+}


### PR DESCRIPTION
This exposes variant names, but doesn't try to expose the field names within those variants as that would require a larger API surface.

Fixes #1 